### PR TITLE
Add mise config symlink

### DIFF
--- a/main.bash
+++ b/main.bash
@@ -94,6 +94,9 @@ main() {
         # zellij
         "${script_dir}/.config/zellij/config.kdl"
         "${HOME}/.config/zellij/config.kdl"
+        # mise
+        "${script_dir}/.config/mise/mise.toml"
+        "${HOME}/.config/mise/mise.toml"
         #
         "${script_dir}/.vimrc"
         "${HOME}/.vimrc"


### PR DESCRIPTION
## 概要

`.config/mise/mise.toml`（中身は空）を追加し、`main.bash setup` の `file_pairs` に登録して `ln -s` で `~/.config/mise/mise.toml` に配置されるようにしました。

## 変更内容

- `.config/mise/mise.toml` を新規作成（空ファイル）
- `main.bash` の `file_pairs` に mise のエントリを追加

既存の zellij などと同じ仕組みで、`Darwin | Linux` ではシンボリックリンク、Windows ではコピーで配置されます。

https://claude.ai/code/session_01VbTD9X2vFpN1xxNBWQ89aZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbTD9X2vFpN1xxNBWQ89aZ)_