### PR TITLE
feat(mise): ensure mise config dir and file exist before writing

### DIFF
--- a/.fish/060_mise.fish
+++ b/.fish/060_mise.fish
@@ -6,6 +6,8 @@ if not command -q mise
   echo "mise is not installed. Refer to 'https://mise.jdx.dev/'"
 else
   set -l mise_config_path ~/.config/mise/config.toml
+  mkdir -p (dirname $mise_config_path)
+  test -f $mise_config_path; or touch $mise_config_path
   set -l pkgs \
     cargo-binstall               latest \
     cargo:bat                    latest \

--- a/shell/060_mise.sh
+++ b/shell/060_mise.sh
@@ -27,6 +27,8 @@ if command -v mise &>/dev/null; then
     exit 1
   fi
   mise_config_path=~/.config/mise/config.toml
+  mkdir -p "$(dirname "${mise_config_path}")"
+  [ -f "${mise_config_path}" ] || touch "${mise_config_path}"
 
   # 複数シェルを同時起動した時に競合するため lock を取る
   exec 3<> /tmp/mise_config_lock  # open file as '3' descriptor


### PR DESCRIPTION
## 概要

`mise_config_path=~/.config/mise/config.toml` を設定した直後に、ディレクトリの作成と `config.toml` の `touch` を行うコードを追加しました。

直後の `grep` / `sed` がこのファイルを前提に動作するため、存在しない場合に失敗するのを防ぎます。

## 変更点

- `shell/060_mise.sh` (bash/zsh 版): `mkdir -p` でディレクトリ作成 + 未存在時に `touch`
- `.fish/060_mise.fish` (fish 版): 同等の処理を追加

https://claude.ai/code/session_01QkRtAnk6JJjDhTKebCgG2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkRtAnk6JJjDhTKebCgG2K)_