### PR TITLE
refactor(mise): create config.toml with [tools] section only when missing

### DIFF
--- a/.fish/060_mise.fish
+++ b/.fish/060_mise.fish
@@ -6,8 +6,6 @@ if not command -q mise
   echo "mise is not installed. Refer to 'https://mise.jdx.dev/'"
 else
   set -l mise_config_path ~/.config/mise/config.toml
-  mkdir -p (dirname $mise_config_path)
-  test -f $mise_config_path; or touch $mise_config_path
   set -l pkgs \
     cargo-binstall               latest \
     cargo:bat                    latest \
@@ -38,6 +36,11 @@ else
     for i in (seq 1 2 (count $pkgs))
       set -l _pkg $pkgs[$i]
       set -l _ver $pkgs[(math $i + 1)]
+      # config.toml がなければ [tools] セクションとともに作成する
+      if not test -f $mise_config_path
+        mkdir -p (dirname $mise_config_path)
+        printf '[tools]\n' > $mise_config_path
+      end
       if not command grep -q -E "^[\"]?"$_pkg"[\"]? =" $mise_config_path
         sed -i '/\[tools\]/a "'"$_pkg"'" = "'"$_ver"'"' $mise_config_path
       end

--- a/shell/060_mise.sh
+++ b/shell/060_mise.sh
@@ -27,8 +27,6 @@ if command -v mise &>/dev/null; then
     exit 1
   fi
   mise_config_path=~/.config/mise/config.toml
-  mkdir -p "$(dirname "${mise_config_path}")"
-  [ -f "${mise_config_path}" ] || touch "${mise_config_path}"
 
   # 複数シェルを同時起動した時に競合するため lock を取る
   exec 3<> /tmp/mise_config_lock  # open file as '3' descriptor
@@ -39,6 +37,11 @@ if command -v mise &>/dev/null; then
   for ((i=0; i<${#pkgs[@]}; i+=2)); do
     pkg="${pkgs[i]}"
     version="${pkgs[i+1]}"
+    # config.toml がなければ [tools] セクションとともに作成する
+    if [ ! -f "${mise_config_path}" ]; then
+      mkdir -p "$(dirname "${mise_config_path}")"
+      printf '[tools]\n' > "${mise_config_path}"
+    fi
     # Use `\` to prevent alias expansion when such like `source ~/.bashrc`
     if ! \grep -q -E "^[\"]?${pkg}[\"]? =" "${mise_config_path:?}"; then
       sed -i '/\[tools\]/a '"\"${pkg}\" = \"${version}\"" "${mise_config_path}"


### PR DESCRIPTION
## 概要

PR #10 で追加した無条件の `mkdir -p` / `touch` を削除し、代わりに `grep`/`sed` の挿入処理の直前で **ファイルが存在しないときだけ** `[tools]` セクションつきで `config.toml` を生成するように変更しました。

`touch` で空ファイルを作っても `sed -i '/\[tools\]/a ...'` の挿入先（`[tools]` 行）が無いため、`[tools]` ヘッダごと作成するようにしています。

## 変更点

- `shell/060_mise.sh` (bash/zsh 版)
- `.fish/060_mise.fish` (fish 版)

両方とも、未存在時に `mkdir -p` + `printf '[tools]\n' > config.toml` で生成します。

https://claude.ai/code/session_01QkRtAnk6JJjDhTKebCgG2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkRtAnk6JJjDhTKebCgG2K)_