### PR TITLE
feat(mise): seed config.toml from a template file

### DIFF
--- a/.config_tmpl/mise/config.toml
+++ b/.config_tmpl/mise/config.toml
@@ -1,0 +1,6 @@
+[settings]
+install_before = "9d"
+lockfile = true
+
+[tools]
+"usage" = "latest"

--- a/.fish/060_mise.fish
+++ b/.fish/060_mise.fish
@@ -36,10 +36,10 @@ else
     for i in (seq 1 2 (count $pkgs))
       set -l _pkg $pkgs[$i]
       set -l _ver $pkgs[(math $i + 1)]
-      # config.toml がなければ [tools] セクションとともに作成する
+      # config.toml がなければテンプレートを初期ファイルとしてコピーする
       if not test -f $mise_config_path
         mkdir -p (dirname $mise_config_path)
-        printf '[tools]\n' > $mise_config_path
+        cp ~/dotfiles/.config_tmpl/mise/config.toml $mise_config_path
       end
       if not command grep -q -E "^[\"]?"$_pkg"[\"]? =" $mise_config_path
         sed -i '/\[tools\]/a "'"$_pkg"'" = "'"$_ver"'"' $mise_config_path

--- a/shell/060_mise.sh
+++ b/shell/060_mise.sh
@@ -37,10 +37,10 @@ if command -v mise &>/dev/null; then
   for ((i=0; i<${#pkgs[@]}; i+=2)); do
     pkg="${pkgs[i]}"
     version="${pkgs[i+1]}"
-    # config.toml がなければ [tools] セクションとともに作成する
+    # config.toml がなければテンプレートを初期ファイルとしてコピーする
     if [ ! -f "${mise_config_path}" ]; then
       mkdir -p "$(dirname "${mise_config_path}")"
-      printf '[tools]\n' > "${mise_config_path}"
+      cp ~/dotfiles/.config_tmpl/mise/config.toml "${mise_config_path}"
     fi
     # Use `\` to prevent alias expansion when such like `source ~/.bashrc`
     if ! \grep -q -E "^[\"]?${pkg}[\"]? =" "${mise_config_path:?}"; then


### PR DESCRIPTION
## 概要

`.config_tmpl/mise/config.toml` を新規作成し、`config.toml` が存在しないときの初期ファイルとして利用するようにしました。これまでの `printf '[tools]\n'` でのヘッダ生成を、テンプレートのコピーに置き換えています。

## テンプレート内容 (`.config_tmpl/mise/config.toml`)

```toml
[settings]
install_before = "9d"
lockfile = true

[tools]
"usage" = "latest"
```

## 変更点

- `.config_tmpl/mise/config.toml` を新規追加
- `shell/060_mise.sh` (bash/zsh 版): 未存在時に `~/dotfiles/.config_tmpl/mise/config.toml` をコピー
- `.fish/060_mise.fish` (fish 版): 同上

https://claude.ai/code/session_01QkRtAnk6JJjDhTKebCgG2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkRtAnk6JJjDhTKebCgG2K)_