### PR TITLE
feat(mise): mise_lock_to_current_global を追加

### DIFF
--- a/.fish/252_alias_mise.fish
+++ b/.fish/252_alias_mise.fish
@@ -2,3 +2,22 @@
 
 abbr m 'mise'
 abbr mr 'mise run'
+
+# 現在 (mise ls --current) で有効なツールのバージョンを mise の設定に固定する。
+# $argv: `mise use` に渡す追加オプション (例: グローバル設定なら "-g")
+function _mise_lock_to_current
+    mise ls --current --json | jq -r --arg opts "$argv" '
+        to_entries[]
+        | "mise use \($opts) --pin \(.key)@\(.value[0].version)"
+    ' | sh
+end
+
+# カレントの設定 (mise.toml 等) に現在のバージョンを固定する
+function mise_lock_to_current --description 'Pin current tool versions to local mise config'
+    _mise_lock_to_current
+end
+
+# グローバル設定 (mise use -g) に現在のバージョンを固定する
+function mise_lock_to_current_global --description 'Pin current tool versions to global mise config'
+    _mise_lock_to_current -g
+end

--- a/.fish/252_alias_mise.fish
+++ b/.fish/252_alias_mise.fish
@@ -3,18 +3,11 @@
 abbr m 'mise'
 abbr mr 'mise run'
 
-# 現在 (mise ls --current) で有効なツールのバージョンを mise の設定に固定する。
-# $argv: `mise use` に渡す追加オプション (例: グローバル設定なら "-g")
+# 現在 (mise ls --current) で有効なツールのバージョンを mise に固定する。
+# 引数なしでカレントの設定 (mise.toml 等) に、`-g` を渡すとグローバル設定に固定する。
+# $argv: `mise use` に渡す追加オプション (例: "-g")
 function _mise_lock_to_current
-    mise ls --current --json | jq -r --arg opts "$argv" '
-        to_entries[]
-        | "mise use \($opts) --pin \(.key)@\(.value[0].version)"
-    ' | sh
-end
-
-# カレントの設定 (mise.toml 等) に現在のバージョンを固定する
-function mise_lock_to_current --description 'Pin current tool versions to local mise config'
-    _mise_lock_to_current
+    mise use $argv --pin (mise ls --current --json | jq -r 'to_entries[] | "\(.key)@\(.value[0].version)"')
 end
 
 # グローバル設定 (mise use -g) に現在のバージョンを固定する

--- a/shell/252_alias_mise.sh
+++ b/shell/252_alias_mise.sh
@@ -2,3 +2,23 @@
 
 alias m='mise'
 alias mr='mise run'
+
+# 現在 (mise ls --current) で有効なツールのバージョンを mise の設定に固定する。
+# $1: `mise use` に渡す追加オプション (例: グローバル設定なら "-g")
+_mise_lock_to_current() {
+  mise ls --current --json |
+    jq -r --arg opts "$1" '
+      to_entries[]
+      | "mise use \($opts) --pin \(.key)@\(.value[0].version)"
+    ' | sh
+}
+
+# カレントの設定 (mise.toml 等) に現在のバージョンを固定する
+mise_lock_to_current() {
+  _mise_lock_to_current ""
+}
+
+# グローバル設定 (mise use -g) に現在のバージョンを固定する
+mise_lock_to_current_global() {
+  _mise_lock_to_current "-g"
+}

--- a/shell/252_alias_mise.sh
+++ b/shell/252_alias_mise.sh
@@ -3,22 +3,15 @@
 alias m='mise'
 alias mr='mise run'
 
-# 現在 (mise ls --current) で有効なツールのバージョンを mise の設定に固定する。
-# $1: `mise use` に渡す追加オプション (例: グローバル設定なら "-g")
+# 現在 (mise ls --current) で有効なツールのバージョンを mise に固定する。
+# 引数なしでカレントの設定 (mise.toml 等) に、`-g` を渡すとグローバル設定に固定する。
+# $@: `mise use` に渡す追加オプション (例: "-g")
 _mise_lock_to_current() {
-  mise ls --current --json |
-    jq -r --arg opts "$1" '
-      to_entries[]
-      | "mise use \($opts) --pin \(.key)@\(.value[0].version)"
-    ' | sh
-}
-
-# カレントの設定 (mise.toml 等) に現在のバージョンを固定する
-mise_lock_to_current() {
-  _mise_lock_to_current ""
+  # shellcheck disable=SC2046  # tool@version を複数引数として単語分割で展開したい
+  mise use "$@" --pin $(mise ls --current --json | jq -r 'to_entries[] | "\(.key)@\(.value[0].version)"')
 }
 
 # グローバル設定 (mise use -g) に現在のバージョンを固定する
 mise_lock_to_current_global() {
-  _mise_lock_to_current "-g"
+  _mise_lock_to_current -g
 }


### PR DESCRIPTION
## 概要

現在 (`mise ls --current`) で有効なツールのバージョンを `mise` の設定ファイルに固定するヘルパーを追加します。

`mise use` が複数の `TOOL@VERSION` を一度に受け取れる性質を使い、`jq` では `tool@version` の一覧だけを生成して、1回の `mise use --pin` にまとめて渡します（コマンド文字列を生成して `| sh` に流す方式は不採用）。

```sh
mise use --pin $(mise ls --current --json | jq -r 'to_entries[] | "\(.key)@\(.value[0].version)"')
```

## 追加した関数

| 関数 | 動作 |
| --- | --- |
| `_mise_lock_to_current` | 現在のバージョンを固定。引数なしでカレント設定 (`mise.toml` 等)、`-g` を渡すとグローバル設定 |
| `mise_lock_to_current_global` | `_mise_lock_to_current -g` のラッパー（グローバル設定に固定） |

ローカル固定は `_mise_lock_to_current` を引数なしで呼び出します。

shell (POSIX `sh` / bash / zsh) 版と fish 版の両方を用意しています。

## 変更ファイル

- `shell/252_alias_mise.sh`
- `.fish/252_alias_mise.fish`

## 動作確認

- `bash -n` による構文チェック: OK
- `mise` をモックして `mise use` に渡る引数を捕捉する end-to-end テストで確認:
  - `_mise_lock_to_current` → `mise use --pin <tool>@<version> ...`
  - `mise_lock_to_current_global` → `mise use -g --pin <tool>@<version> ...`
  - 各 `tool@version` が個別の引数として展開されること、`mise_lock_to_current` が未定義であること
- fish は当環境に未インストールのため構文を手動レビュー（コマンド置換 `(...)` が改行区切りでリスト化される点、空の `$argv`（unquoted）が0引数に展開される点を確認）

## 補足

- shell 版は POSIX `sh` に配列が無いため、コマンド置換を意図的に unquoted にして単語分割で複数引数化しています（`SC2046` を意図的に無効化）。`tool@version` は空白・グロブ文字を含まないため安全です。

https://claude.ai/code/session_019o5ZXK23GyCxNeXjvw6fEZ