### PR TITLE
feat(mise): pin current versions to global config once a day after install

### DIFF
--- a/.fish/252_alias_mise.fish
+++ b/.fish/252_alias_mise.fish
@@ -14,3 +14,17 @@ end
 function mise_lock_to_current_global --description 'Pin current tool versions to global mise config'
     _mise_lock_to_current -g
 end
+
+# mise install (060_mise.fish) の後、現在のツールバージョンをグローバル設定へ
+# 1 日 1 回だけ pin する。読み込み順 (060_mise.fish → 252_alias_mise.fish) により
+# mise install の完了後に実行される。
+# フラグ (mtime) で 1 日 1 回、flock で多重起動時の競合を制御する。
+begin
+    set -l _lock_flag ~/.config/mise/.mise_last_lock
+    flock -x 9
+    if not test -f $_lock_flag; or test (math (date +%s) - (stat -c %Y $_lock_flag 2>/dev/null; or echo 0)) -gt 86400
+        echo "== Pinning current mise tool versions to global config =="
+        mise_lock_to_current_global
+        touch $_lock_flag
+    end
+end 9>/tmp/mise_lock_to_current_lock

--- a/shell/252_alias_mise.sh
+++ b/shell/252_alias_mise.sh
@@ -15,3 +15,19 @@ _mise_lock_to_current() {
 mise_lock_to_current_global() {
   _mise_lock_to_current -g
 }
+
+# mise install (060_mise.sh) の後、現在のツールバージョンをグローバル設定へ
+# 1 日 1 回だけ pin する。読み込み順 (060_mise.sh → 252_alias_mise.sh) により
+# mise install の完了後に実行される。
+# フラグ (mtime) で 1 日 1 回、flock で多重起動時の競合を制御する。
+_mise_lock_flag=~/.config/mise/.mise_last_lock
+{
+  flock -x 9
+  if [ ! -f "${_mise_lock_flag}" ] || \
+     [ "$(( $(date +%s) - $(stat -c %Y "${_mise_lock_flag}" 2>/dev/null || echo 0) ))" -gt 86400 ]; then
+    echo "== Pinning current mise tool versions to global config =="
+    mise_lock_to_current_global
+    touch "${_mise_lock_flag}"
+  fi
+} 9>/tmp/mise_lock_to_current_lock
+unset _mise_lock_flag


### PR DESCRIPTION
## 概要

`mise install` の後に、現在のツールバージョンをグローバル設定 (`~/.config/mise/config.toml`) へ **1 日 1 回だけ** pin する処理を rc に追加しました（`mise_lock_to_current_global` 相当）。

## 背景

- 既存の `mise_lock_to_current_global` 関数（`mise use -g --pin ...`）は手動実行用に定義済みでしたが、自動では呼ばれていませんでした。
- `mise install` でツールが更新された後、現在のバージョンをグローバル設定へ pin して再現性を保ちたい、という要望に対応します。

## 変更内容

`252_alias_mise.{sh,fish}` の関数定義直後に、`mise_lock_to_current_global` を **1 日 1 回だけ** 呼び出すガード付きブロックを追加しました。

- `shell/252_alias_mise.sh` (bash / zsh 用)
- `.fish/252_alias_mise.fish` (fish 用)

### 設計

- **実行タイミング**: rc の読み込み順は `060_mise.*`（`mise install`）→ `252_alias_mise.*`（lock 関数定義）です。`060` 実行時点では lock 関数が未定義のため、関数定義のある `252` の末尾に呼び出しを置くことで、起動フロー上 `mise install` の完了後に実行されます。既存関数を再利用し、pin ロジックの重複を避けています。
- **頻度（1 日 1 回）**: フラグ `~/.config/mise/.mise_last_lock` の mtime を見て 24 時間以上経過していれば実行し、`touch` で更新します。bash/zsh の `mise install` 自体の毎起動動作は変更していません（lock のみ日次に抑制）。
- **競合制御**: `flock` でロックファイル `/tmp/mise_lock_to_current_lock` を排他取得し、複数シェル同時起動時の競合を防ぎます。flock の fd はフラグファイルとは別ファイルにしているため、ロック取得でフラグの mtime が書き換わる問題はありません。

## 確認

- `sh -n` / `bash -n` / `shellcheck` (sh): 構文チェック・lint クリーン
- `fish -n` (fish): 構文チェック OK
- ガードロジックを `mise`/`jq` をスタブして機能確認: 初回=実行 → 24h 以内=スキップ → 25h 経過=実行 → 直後=スキップ、と意図通り動作（sh / fish 両方）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kQvS1im8RXzuBmhjQWhXE

---
_Generated by [Claude Code](https://claude.ai/code/session_019kQvS1im8RXzuBmhjQWhXE)_